### PR TITLE
chore(rename): rename appsource to system.Source

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -14,7 +14,7 @@ import (
 	"github.com/suborbital/appspec/tenant"
 )
 
-// Bundle represents a Runnable bundle.
+// Bundle represents a Module bundle.
 type Bundle struct {
 	filepath     string
 	TenantConfig *tenant.Config
@@ -63,7 +63,7 @@ func (b *Bundle) StaticFile(filePath string) ([]byte, error) {
 	return contents, nil
 }
 
-// Write writes a runnable bundle
+// Write writes a module bundle
 // based loosely on https://golang.org/src/archive/zip/example_test.go
 // staticFiles should be a map of *relative* filepaths to their associated files, with or without the `static/` prefix.
 func Write(tenantConfigBytes []byte, modules []os.File, staticFiles map[string]os.File, targetPath string) error {
@@ -207,14 +207,14 @@ func Read(path string) (*Bundle, error) {
 		// for now, the bundle spec only supports the default namespace
 		FQMN := fmt.Sprintf("/name/default/%s", strings.TrimSuffix(f.Name, ".wasm"))
 
-		runnable, err := bundle.TenantConfig.FindModule(FQMN)
+		module, err := bundle.TenantConfig.FindModule(FQMN)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to FindModule for %s (%s)", f.Name, FQMN)
-		} else if runnable == nil {
+		} else if module == nil {
 			return nil, fmt.Errorf("unable to find Module for Wasm file %s (%s)", f.Name, FQMN)
 		}
 
-		runnable.WasmRef = tenant.NewWasmModuleRef(f.Name, runnable.FQMN, wasmBytes)
+		module.WasmRef = tenant.NewWasmModuleRef(f.Name, module.FQMN, wasmBytes)
 	}
 
 	if bundle.TenantConfig == nil {

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -37,6 +37,6 @@ package bundle
 // 	}
 
 // 	if !hasDefault {
-// 		t.Error("helloworld-rs.wasm runnable not found in bundle or missing ModuleReference")
+// 		t.Error("helloworld-rs.wasm module not found in bundle or missing ModuleReference")
 // 	}
 // }

--- a/capabilities/cache.go
+++ b/capabilities/cache.go
@@ -23,7 +23,7 @@ type CacheRules struct {
 	AllowDelete bool `json:"allowDelete" yaml:"allowDelete"`
 }
 
-// CacheCapability gives Runnables access to a key/value cache
+// CacheCapability gives Modules access to a key/value cache
 type CacheCapability interface {
 	Set(key string, val []byte, ttl int) error
 	Get(key string) ([]byte, error)

--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -7,7 +7,7 @@ import (
 
 var ErrCapabilityNotAvailable = errors.New("capability not available")
 
-// Capabilities define the capabilities available to a Runnable
+// Capabilities define the capabilities available to a Module
 type Capabilities struct {
 	config CapabilityConfig
 

--- a/capabilities/config.go
+++ b/capabilities/config.go
@@ -7,7 +7,7 @@ import (
 
 var ErrCapabilityNotEnabled = errors.New("capability is not enabled")
 
-// CapabilityConfig is configuration for a Runnable's capabilities
+// CapabilityConfig is configuration for a Module's capabilities
 // NOTE: if any of the individual configs are nil, it will cause a crash,
 // but we need to be able to determine if they're set or not, hence the pointers
 // we are going to leave capabilities undocumented until we come up with a more elegant solution

--- a/capabilities/httpclient.go
+++ b/capabilities/httpclient.go
@@ -15,7 +15,7 @@ type HTTPConfig struct {
 	Rules   HTTPRules `json:"rules" yaml:"rules"`
 }
 
-// HTTPCapability gives Runnables the ability to make HTTP requests
+// HTTPCapability gives Modules the ability to make HTTP requests
 type HTTPCapability interface {
 	Do(auth AuthCapability, method, urlString string, body []byte, headers http.Header) (*http.Response, error)
 }

--- a/capabilities/logger.go
+++ b/capabilities/logger.go
@@ -8,7 +8,7 @@ type LoggerConfig struct {
 	Logger  *vlog.Logger `json:"-" yaml:"-"`
 }
 
-// LoggerCapability provides a logger to Runnables
+// LoggerCapability provides a logger to Modules
 type LoggerCapability interface {
 	Log(level int32, msg string, scope interface{})
 }

--- a/fqmn/fqmn.go
+++ b/fqmn/fqmn.go
@@ -9,7 +9,7 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////////
 // An FQMN (fully-qualified module name) is a "globally unique"
-// name for a specific module from a specific application ref
+// name for a specific module from a specific tenant ref
 // example: fqmn://suborbital.acmeco/api-users/add-user@98qhrfgo3089hafrouhqf48
 // i.e. fqmn://<tenant>/<namespace>/<modname>@<ref>
 //
@@ -169,7 +169,7 @@ func MigrateV1ToV2(name, ref string) (FQMN, error) {
 		name = tenantParts[1]
 	}
 
-	// if a Runnable is referenced with its namespace, i.e. users#getUser
+	// if a Module is referenced with its namespace, i.e. users#getUser
 	// then we need to parse that and ensure we only match that namespace.
 
 	namespace := NamespaceDefault
@@ -179,7 +179,7 @@ func MigrateV1ToV2(name, ref string) (FQMN, error) {
 		name = namespaceParts[1]
 	}
 
-	// next, if the name contains an @, parse the name and ignore app version.
+	// next, if the name contains an @, parse the name and ignore tenant version.
 	versionParts := strings.SplitN(name, "@", 2)
 	if len(versionParts) == 2 {
 		name = versionParts[0]

--- a/request/request.go
+++ b/request/request.go
@@ -18,7 +18,7 @@ const (
 )
 
 // CoordinatedRequest represents a request whose fulfillment can be coordinated across multiple hosts
-// and is serializable to facilitate interoperation with Wasm Runnables and transmissible over the wire
+// and is serializable to facilitate interoperation with Wasm Modules and transmissible over the wire
 type CoordinatedRequest struct {
 	Method       string            `json:"method"`
 	URL          string            `json:"url"`

--- a/system/auth.go
+++ b/system/auth.go
@@ -1,4 +1,4 @@
-package appsource
+package system
 
 import (
 	"context"

--- a/system/bundle/bundlesource.go
+++ b/system/bundle/bundlesource.go
@@ -32,7 +32,7 @@ func NewBundleSource(path string) system.Source {
 	return b
 }
 
-// Start initializes the app source.
+// Start initializes the system source.
 func (b *BundleSource) Start(opts system.Options) error {
 	b.opts = opts
 
@@ -68,7 +68,7 @@ func (b *BundleSource) Overview() (*system.Overview, error) {
 	return ovv, nil
 }
 
-// Runnables returns the Runnables for the app.
+// Modules returns the Modules for the system.
 func (b *BundleSource) TenantOverview(ident string) (*system.TenantOverview, error) {
 	if !b.checkIdentifier(ident) {
 		return nil, system.ErrTenantNotFound
@@ -90,7 +90,7 @@ func (b *BundleSource) TenantOverview(ident string) (*system.TenantOverview, err
 	return ovv, nil
 }
 
-// FindRunnable searches for and returns the requested runnable
+// FindRunnable searches for and returns the requested module
 // otherwise system.ErrFunctionNotFound.
 func (b *BundleSource) GetModule(FQMN string) (*tenant.Module, error) {
 	b.lock.RLock()
@@ -109,7 +109,7 @@ func (b *BundleSource) GetModule(FQMN string) (*tenant.Module, error) {
 	return nil, system.ErrModuleNotFound
 }
 
-// Schedules returns the schedules for the app.
+// Schedules returns the schedules for the system.
 func (b *BundleSource) Workflows(ident, namespace string, version int64) ([]tenant.Workflow, error) {
 	if !b.checkIdentifier(ident) {
 		return nil, system.ErrTenantNotFound
@@ -135,7 +135,7 @@ func (b *BundleSource) Workflows(ident, namespace string, version int64) ([]tena
 	return nil, system.ErrNamespaceNotFound
 }
 
-// Connections returns the Connections for the app.
+// Connections returns the Connections for the system.
 func (b *BundleSource) Connections(ident, namespace string, version int64) ([]tenant.Connection, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
@@ -161,7 +161,7 @@ func (b *BundleSource) Connections(ident, namespace string, version int64) ([]te
 	return nil, system.ErrTenantNotFound
 }
 
-// Authentication returns the Authentication for the app.
+// Authentication returns the Authentication for the system.
 func (b *BundleSource) Authentication(ident, namespace string, version int64) (*tenant.Authentication, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
@@ -187,7 +187,7 @@ func (b *BundleSource) Authentication(ident, namespace string, version int64) (*
 	return nil, system.ErrTenantNotFound
 }
 
-// Capabilities returns the configuration for the app's capabilities.
+// Capabilities returns the configuration for the system's capabilities.
 
 func (b *BundleSource) Capabilities(ident, namespace string, version int64) (*capabilities.CapabilityConfig, error) {
 	defaultConfig := capabilities.DefaultCapabilityConfig()
@@ -232,7 +232,7 @@ func (b *BundleSource) StaticFile(ident string, tenantVersion int64, filename st
 	return b.bundle.StaticFile(filename)
 }
 
-// Queries returns the Queries available to the app.
+// Queries returns the Queries available to the system.
 func (b *BundleSource) Queries(ident, namespace string, version int64) ([]tenant.DBQuery, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
@@ -287,7 +287,7 @@ func (b *BundleSource) findBundle() error {
 	return nil
 }
 
-// checkIdentifier checks whether the passed in identifier and version are for the current app running in the
+// checkIdentifier checks whether the passed in identifier and version are for the current system running in the
 // bundle or not. Returns true only if both match.
 func (b *BundleSource) checkIdentifier(identifier string) bool {
 	return b.bundle.TenantConfig.Identifier == identifier

--- a/system/bundle/bundlesource.go
+++ b/system/bundle/bundlesource.go
@@ -13,7 +13,7 @@ import (
 	"github.com/suborbital/appspec/tenant"
 )
 
-// BundleSource is an Source backed by a bundle file.
+// BundleSource is a Source backed by a bundle file.
 type BundleSource struct {
 	path   string
 	opts   system.Options
@@ -90,8 +90,8 @@ func (b *BundleSource) TenantOverview(ident string) (*system.TenantOverview, err
 	return ovv, nil
 }
 
-// FindRunnable searches for and returns the requested module
-// otherwise system.ErrFunctionNotFound.
+// GetModule searches for and returns the requested module
+// otherwise system.ErrModuleNotFound.
 func (b *BundleSource) GetModule(FQMN string) (*tenant.Module, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()

--- a/system/capabilities.go
+++ b/system/capabilities.go
@@ -1,4 +1,4 @@
-package appsource
+package system
 
 import (
 	"github.com/pkg/errors"
@@ -9,8 +9,8 @@ import (
 )
 
 // ResolveCapabilitiesFromSource takes the ident, namespace, and version, and looks up the capabilities for that trio from the
-// AppSource applying the user overrides over the default configurations.
-func ResolveCapabilitiesFromSource(source AppSource, ident, namespace string, log *vlog.Logger) (*capabilities.CapabilityConfig, error) {
+// Source applying the user overrides over the default configurations.
+func ResolveCapabilitiesFromSource(source Source, ident, namespace string, log *vlog.Logger) (*capabilities.CapabilityConfig, error) {
 	defaultConfig := capabilities.DefaultCapabilityConfig()
 
 	tenantOverview, err := source.TenantOverview(ident)

--- a/system/client/httpsource.go
+++ b/system/client/httpsource.go
@@ -38,7 +38,7 @@ func NewHTTPSource(host string, creds system.CredentialSupplier) system.Source {
 	return h
 }
 
-// Start initializes the app source.
+// Start initializes the system source.
 func (h *HTTPSource) Start(opts system.Options) error {
 	h.opts = opts
 
@@ -83,7 +83,7 @@ func (h *HTTPSource) TenantOverview(ident string) (*system.TenantOverview, error
 	return ovv, nil
 }
 
-// GetModule returns a nil error if a Runnable with the
+// GetModule returns a nil error if a Module with the
 // provided FQMN can be made available at the next sync,
 // otherwise ErrRunnableNotFound is returned.
 func (h *HTTPSource) GetModule(FQMN string) (*tenant.Module, error) {
@@ -115,7 +115,7 @@ func (h *HTTPSource) GetModule(FQMN string) (*tenant.Module, error) {
 	return module, nil
 }
 
-// Workflows returns the Workflows for the app.
+// Workflows returns the Workflows for the system.
 func (h *HTTPSource) Workflows(ident, namespace string, version int64) ([]tenant.Workflow, error) {
 	workflows := make([]tenant.Workflow, 0)
 
@@ -127,7 +127,7 @@ func (h *HTTPSource) Workflows(ident, namespace string, version int64) ([]tenant
 	return workflows, nil
 }
 
-// Connections returns the Connections for the app.
+// Connections returns the Connections for the system.
 func (h *HTTPSource) Connections(ident, namespace string, version int64) ([]tenant.Connection, error) {
 	connections := []tenant.Connection{}
 
@@ -139,7 +139,7 @@ func (h *HTTPSource) Connections(ident, namespace string, version int64) ([]tena
 	return connections, nil
 }
 
-// Authentication returns the Authentication for the app.
+// Authentication returns the Authentication for the system.
 func (h *HTTPSource) Authentication(ident, namespace string, version int64) (*tenant.Authentication, error) {
 	authentication := &tenant.Authentication{}
 
@@ -150,7 +150,7 @@ func (h *HTTPSource) Authentication(ident, namespace string, version int64) (*te
 	return authentication, nil
 }
 
-// Capabilities returns the Capabilities for the app.
+// Capabilities returns the Capabilities for the system.
 func (h *HTTPSource) Capabilities(ident, namespace string, version int64) (*capabilities.CapabilityConfig, error) {
 	capabilities := &capabilities.CapabilityConfig{}
 
@@ -181,7 +181,7 @@ func (h *HTTPSource) StaticFile(ident string, version int64, filename string) ([
 	return file, nil
 }
 
-// Queries returns the Queries for the app.
+// Queries returns the Queries for the system.
 func (h *HTTPSource) Queries(ident, namespace string, version int64) ([]tenant.DBQuery, error) {
 	queries := make([]tenant.DBQuery, 0)
 

--- a/system/client/httpsource.go
+++ b/system/client/httpsource.go
@@ -12,21 +12,21 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/suborbital/appspec/appsource"
 	"github.com/suborbital/appspec/capabilities"
 	"github.com/suborbital/appspec/fqmn"
+	"github.com/suborbital/appspec/system"
 	"github.com/suborbital/appspec/tenant"
 )
 
-// HTTPSource is an AppSource backed by an HTTP client connected to a remote source.
+// HTTPSource is an Source backed by an HTTP client connected to a remote source.
 type HTTPSource struct {
 	host       string
 	authHeader string
-	opts       appsource.Options
+	opts       system.Options
 }
 
 // NewHTTPSource creates a new HTTPSource that looks for a bundle at [host].
-func NewHTTPSource(host string, creds appsource.CredentialSupplier) appsource.AppSource {
+func NewHTTPSource(host string, creds system.CredentialSupplier) system.Source {
 	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
 		host = fmt.Sprintf("http://%s", host)
 	}
@@ -39,7 +39,7 @@ func NewHTTPSource(host string, creds appsource.CredentialSupplier) appsource.Ap
 }
 
 // Start initializes the app source.
-func (h *HTTPSource) Start(opts appsource.Options) error {
+func (h *HTTPSource) Start(opts system.Options) error {
 	h.opts = opts
 
 	if err := h.pingServer(); err != nil {
@@ -50,9 +50,9 @@ func (h *HTTPSource) Start(opts appsource.Options) error {
 }
 
 // State returns the state of the entire system
-func (h *HTTPSource) State() (*appsource.State, error) {
-	s := &appsource.State{}
-	if _, err := h.get("/appsource/v1/state", s); err != nil {
+func (h *HTTPSource) State() (*system.State, error) {
+	s := &system.State{}
+	if _, err := h.get("/system/v1/state", s); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /state"))
 		return nil, errors.Wrap(err, "failed to get /state")
 	}
@@ -61,9 +61,9 @@ func (h *HTTPSource) State() (*appsource.State, error) {
 }
 
 // Overview gets the overview for the entire system.
-func (h *HTTPSource) Overview() (*appsource.Overview, error) {
-	ovv := &appsource.Overview{}
-	if _, err := h.get("/appsource/v1/overview", ovv); err != nil {
+func (h *HTTPSource) Overview() (*system.Overview, error) {
+	ovv := &system.Overview{}
+	if _, err := h.get("/system/v1/overview", ovv); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /overview"))
 		return nil, errors.Wrap(err, "failed to get /overview")
 	}
@@ -72,10 +72,10 @@ func (h *HTTPSource) Overview() (*appsource.Overview, error) {
 }
 
 // TenantOverview gets the overview for a given tenant.
-func (h *HTTPSource) TenantOverview(ident string) (*appsource.TenantOverview, error) {
-	ovv := &appsource.TenantOverview{}
+func (h *HTTPSource) TenantOverview(ident string) (*system.TenantOverview, error) {
+	ovv := &system.TenantOverview{}
 
-	if _, err := h.get(fmt.Sprintf("/appsource/v1/tenant/%s", ident), ovv); err != nil {
+	if _, err := h.get(fmt.Sprintf("/system/v1/tenant/%s", ident), ovv); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get tenant overview"))
 		return nil, errors.Wrap(err, "failed to get tenant overview")
 	}
@@ -92,24 +92,24 @@ func (h *HTTPSource) GetModule(FQMN string) (*tenant.Module, error) {
 		return nil, errors.Wrap(err, "failed to Parse FQMN")
 	}
 
-	path := fmt.Sprintf("/appsource/v1/module%s", f.URLPath())
+	path := fmt.Sprintf("/system/v1/module%s", f.URLPath())
 
 	module := &tenant.Module{}
 	if resp, err := h.authedGet(path, h.authHeader, module); err != nil {
 		h.opts.Logger().Error(errors.Wrapf(err, "failed to get %s", path))
 
 		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, appsource.ErrAuthenticationFailed
+			return nil, system.ErrAuthenticationFailed
 		}
 
-		return nil, appsource.ErrModuleNotFound
+		return nil, system.ErrModuleNotFound
 	}
 
 	if h.authHeader != "" {
 		// if we get this far, we assume the token was used to successfully get
 		// the module from the control plane, and should therefore be used to
 		// authenticate further calls for this function, so we cache its hash.
-		module.TokenHash = appsource.TokenHash(h.authHeader)
+		module.TokenHash = system.TokenHash(h.authHeader)
 	}
 
 	return module, nil
@@ -119,7 +119,7 @@ func (h *HTTPSource) GetModule(FQMN string) (*tenant.Module, error) {
 func (h *HTTPSource) Workflows(ident, namespace string, version int64) ([]tenant.Workflow, error) {
 	workflows := make([]tenant.Workflow, 0)
 
-	if _, err := h.get(fmt.Sprintf("/appsource/v1/workflows/%s/%s/%d", ident, namespace, version), &workflows); err != nil {
+	if _, err := h.get(fmt.Sprintf("/system/v1/workflows/%s/%s/%d", ident, namespace, version), &workflows); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /workflows"))
 		return nil, errors.Wrap(err, "failed to get /schedules")
 	}
@@ -131,7 +131,7 @@ func (h *HTTPSource) Workflows(ident, namespace string, version int64) ([]tenant
 func (h *HTTPSource) Connections(ident, namespace string, version int64) ([]tenant.Connection, error) {
 	connections := []tenant.Connection{}
 
-	if _, err := h.get(fmt.Sprintf("/appsource/v1/connections/%s/%s/%d", ident, namespace, version), &connections); err != nil {
+	if _, err := h.get(fmt.Sprintf("/system/v1/connections/%s/%s/%d", ident, namespace, version), &connections); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /connections"))
 		return nil, errors.Wrap(err, "failed to get /connections")
 	}
@@ -143,7 +143,7 @@ func (h *HTTPSource) Connections(ident, namespace string, version int64) ([]tena
 func (h *HTTPSource) Authentication(ident, namespace string, version int64) (*tenant.Authentication, error) {
 	authentication := &tenant.Authentication{}
 
-	if _, err := h.get(fmt.Sprintf("/appsource/v1/authentication/%s/%s/%d", ident, namespace, version), authentication); err != nil {
+	if _, err := h.get(fmt.Sprintf("/system/v1/authentication/%s/%s/%d", ident, namespace, version), authentication); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /authentication"))
 	}
 
@@ -154,7 +154,7 @@ func (h *HTTPSource) Authentication(ident, namespace string, version int64) (*te
 func (h *HTTPSource) Capabilities(ident, namespace string, version int64) (*capabilities.CapabilityConfig, error) {
 	capabilities := &capabilities.CapabilityConfig{}
 
-	if _, err := h.get(fmt.Sprintf("/appsource/v1/capabilities/%s/%s/%d", ident, namespace, version), capabilities); err != nil {
+	if _, err := h.get(fmt.Sprintf("/system/v1/capabilities/%s/%s/%d", ident, namespace, version), capabilities); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /capabilities"))
 		return nil, errors.Wrap(err, "failed to get /capabilities")
 	}
@@ -164,7 +164,7 @@ func (h *HTTPSource) Capabilities(ident, namespace string, version int64) (*capa
 
 // StaticFile returns a requested file.
 func (h *HTTPSource) StaticFile(ident string, version int64, filename string) ([]byte, error) {
-	path := fmt.Sprintf("/appsource/v1/file/%s/%d/%s", ident, version, filename)
+	path := fmt.Sprintf("/system/v1/file/%s/%d/%s", ident, version, filename)
 
 	resp, err := h.get(path, nil)
 	if err != nil {
@@ -185,7 +185,7 @@ func (h *HTTPSource) StaticFile(ident string, version int64, filename string) ([
 func (h *HTTPSource) Queries(ident, namespace string, version int64) ([]tenant.DBQuery, error) {
 	queries := make([]tenant.DBQuery, 0)
 
-	if _, err := h.get(fmt.Sprintf("/appsource/v1/queries/%s/%s/%d", ident, namespace, version), &queries); err != nil {
+	if _, err := h.get(fmt.Sprintf("/system/v1/queries/%s/%s/%d", ident, namespace, version), &queries); err != nil {
 		h.opts.Logger().Error(errors.Wrap(err, "failed to get /queries"))
 		return nil, errors.Wrap(err, "failed to get /queries")
 	}
@@ -196,7 +196,7 @@ func (h *HTTPSource) Queries(ident, namespace string, version int64) ([]tenant.D
 // pingServer loops forever until it finds a server at the configured host.
 func (h *HTTPSource) pingServer() error {
 	for {
-		if _, err := h.get("/appsource/v1/state", nil); err != nil {
+		if _, err := h.get("/system/v1/state", nil); err != nil {
 
 			h.opts.Logger().Warn("failed to connect to remote source, will retry:", err.Error())
 

--- a/system/client/httpsource.go
+++ b/system/client/httpsource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/suborbital/appspec/tenant"
 )
 
-// HTTPSource is an Source backed by an HTTP client connected to a remote source.
+// HTTPSource is a Source backed by an HTTP client connected to a remote source.
 type HTTPSource struct {
 	host       string
 	authHeader string

--- a/system/options.go
+++ b/system/options.go
@@ -1,8 +1,8 @@
-package appsource
+package system
 
 import "github.com/suborbital/vektor/vlog"
 
-// Options describes the options for an appsource
+// Options describes the options for an system
 type Options interface {
 	Logger() *vlog.Logger
 }

--- a/system/overview.go
+++ b/system/overview.go
@@ -1,4 +1,4 @@
-package appsource
+package system
 
 import "github.com/suborbital/appspec/tenant"
 

--- a/system/overview.go
+++ b/system/overview.go
@@ -7,13 +7,13 @@ type State struct {
 	SystemVersion int64 `json:"systemVersion"`
 }
 
-// Overview is an overview of all the applications within the system
+// Overview is an overview of all the tenants within the system
 type Overview struct {
 	State
 	TenantRefs References `json:"tenantReferences"`
 }
 
-// References are maps of all the available applications in the system
+// References are maps of all the available tenants in the system
 type References struct {
 	// map of all tenant idents to their latest tenant version
 	Identifiers map[string]int64 `json:"identifiers"`

--- a/system/server/serversource.go
+++ b/system/server/serversource.go
@@ -8,20 +8,20 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/suborbital/appspec/appsource"
 	fqmn "github.com/suborbital/appspec/fqmn"
+	"github.com/suborbital/appspec/system"
 	"github.com/suborbital/vektor/vk"
 )
 
 // AppSourceVKRouter is a helper struct to generate a VK router that can serve
-// an HTTP AppSource based on an actual AppSource object.
+// an HTTP Source based on an actual Source object.
 type AppSourceVKRouter struct {
-	appSource appsource.AppSource
-	options   appsource.Options
+	appSource system.Source
+	options   system.Options
 }
 
 // NewAppSourceVKRouter creates a new AppSourceVKRouter.
-func NewAppSourceVKRouter(appSource appsource.AppSource, opts appsource.Options) *AppSourceVKRouter {
+func NewAppSourceVKRouter(appSource system.Source, opts system.Options) *AppSourceVKRouter {
 	h := &AppSourceVKRouter{
 		appSource: appSource,
 		options:   opts,
@@ -30,7 +30,7 @@ func NewAppSourceVKRouter(appSource appsource.AppSource, opts appsource.Options)
 	return h
 }
 
-// GenerateRouter generates a VK router that uses an AppSource to serve data.
+// GenerateRouter generates a VK router that uses an Source to serve data.
 func (a *AppSourceVKRouter) GenerateRouter() (*vk.Router, error) {
 	if err := a.appSource.Start(a.options); err != nil {
 		return nil, errors.Wrap(err, "failed to appSource.Start")
@@ -38,7 +38,7 @@ func (a *AppSourceVKRouter) GenerateRouter() (*vk.Router, error) {
 
 	router := vk.NewRouter(a.options.Logger(), "")
 
-	v1 := vk.Group("/appsource/v1")
+	v1 := vk.Group("/system/v1")
 
 	v1.GET("/state", a.StateHandler())
 	v1.GET("/overview", a.OverviewHandler())
@@ -99,9 +99,9 @@ func (a *AppSourceVKRouter) GetModuleHandler() vk.HandlerFunc {
 		if err != nil {
 			ctx.Log.Error(errors.Wrap(err, "failed to GetFunction"))
 
-			if errors.Is(err, appsource.ErrModuleNotFound) {
+			if errors.Is(err, system.ErrModuleNotFound) {
 				return nil, vk.Wrap(http.StatusNotFound, fmt.Errorf("failed to find function %s", fqmnString))
-			} else if errors.Is(err, appsource.ErrAuthenticationFailed) {
+			} else if errors.Is(err, system.ErrAuthenticationFailed) {
 				return nil, vk.E(http.StatusUnauthorized, "unauthorized")
 			}
 

--- a/system/server/serversource.go
+++ b/system/server/serversource.go
@@ -16,15 +16,15 @@ import (
 // AppSourceVKRouter is a helper struct to generate a VK router that can serve
 // an HTTP Source based on an actual Source object.
 type AppSourceVKRouter struct {
-	appSource system.Source
-	options   system.Options
+	source  system.Source
+	options system.Options
 }
 
 // NewAppSourceVKRouter creates a new AppSourceVKRouter.
-func NewAppSourceVKRouter(appSource system.Source, opts system.Options) *AppSourceVKRouter {
+func NewAppSourceVKRouter(source system.Source, opts system.Options) *AppSourceVKRouter {
 	h := &AppSourceVKRouter{
-		appSource: appSource,
-		options:   opts,
+		source:  source,
+		options: opts,
 	}
 
 	return h
@@ -32,8 +32,8 @@ func NewAppSourceVKRouter(appSource system.Source, opts system.Options) *AppSour
 
 // GenerateRouter generates a VK router that uses an Source to serve data.
 func (a *AppSourceVKRouter) GenerateRouter() (*vk.Router, error) {
-	if err := a.appSource.Start(a.options); err != nil {
-		return nil, errors.Wrap(err, "failed to appSource.Start")
+	if err := a.source.Start(a.options); err != nil {
+		return nil, errors.Wrap(err, "failed to source.Start")
 	}
 
 	router := vk.NewRouter(a.options.Logger(), "")
@@ -60,14 +60,14 @@ func (a *AppSourceVKRouter) GenerateRouter() (*vk.Router, error) {
 // State is a handler to fetch the system State.
 func (a *AppSourceVKRouter) StateHandler() vk.HandlerFunc {
 	return func(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
-		return a.appSource.State()
+		return a.source.State()
 	}
 }
 
 // OverviewHandler is a handler to fetch the system overview.
 func (a *AppSourceVKRouter) OverviewHandler() vk.HandlerFunc {
 	return func(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
-		return a.appSource.Overview()
+		return a.source.Overview()
 	}
 }
 
@@ -76,7 +76,7 @@ func (a *AppSourceVKRouter) TenantOverviewHandler() vk.HandlerFunc {
 	return func(r *http.Request, ctx *vk.Ctx) (interface{}, error) {
 		ident := ctx.Params.ByName("ident")
 
-		return a.appSource.TenantOverview(ident)
+		return a.source.TenantOverview(ident)
 	}
 }
 
@@ -95,7 +95,7 @@ func (a *AppSourceVKRouter) GetModuleHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusInternalServerError, "something went wrong")
 		}
 
-		runnable, err := a.appSource.GetModule(fqmnString)
+		module, err := a.source.GetModule(fqmnString)
 		if err != nil {
 			ctx.Log.Error(errors.Wrap(err, "failed to GetFunction"))
 
@@ -108,7 +108,7 @@ func (a *AppSourceVKRouter) GetModuleHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusInternalServerError, "something went wrong")
 		}
 
-		return runnable, nil
+		return module, nil
 	}
 }
 
@@ -122,7 +122,7 @@ func (a *AppSourceVKRouter) WorkflowsHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusBadRequest, "bad request")
 		}
 
-		return a.appSource.Workflows(ident, namespace, int64(version))
+		return a.source.Workflows(ident, namespace, int64(version))
 	}
 }
 
@@ -136,7 +136,7 @@ func (a *AppSourceVKRouter) ConnectionsHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusBadRequest, "bad request")
 		}
 
-		return a.appSource.Connections(ident, namespace, int64(version))
+		return a.source.Connections(ident, namespace, int64(version))
 	}
 }
 
@@ -150,7 +150,7 @@ func (a *AppSourceVKRouter) AuthenticationHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusBadRequest, "bad request")
 		}
 
-		return a.appSource.Authentication(ident, namespace, int64(version))
+		return a.source.Authentication(ident, namespace, int64(version))
 	}
 }
 
@@ -164,7 +164,7 @@ func (a *AppSourceVKRouter) CapabilitiesHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusBadRequest, "bad request")
 		}
 
-		return a.appSource.Capabilities(ident, namespace, int64(version))
+		return a.source.Capabilities(ident, namespace, int64(version))
 	}
 }
 
@@ -179,7 +179,7 @@ func (a *AppSourceVKRouter) FileHandler() vk.HandlerFunc {
 			return nil, vk.E(http.StatusBadRequest, "bad request")
 		}
 
-		fileBytes, err := a.appSource.StaticFile(ident, int64(version), filename)
+		fileBytes, err := a.source.StaticFile(ident, int64(version), filename)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return nil, vk.E(http.StatusNotFound, "not found")
@@ -201,6 +201,6 @@ func (a *AppSourceVKRouter) QueriesHandler() vk.HandlerFunc {
 		if err != nil {
 			return nil, vk.E(http.StatusBadRequest, "bad request")
 		}
-		return a.appSource.Queries(ident, namespace, int64(version))
+		return a.source.Queries(ident, namespace, int64(version))
 	}
 }

--- a/system/server/serversource.go
+++ b/system/server/serversource.go
@@ -30,7 +30,7 @@ func NewAppSourceVKRouter(source system.Source, opts system.Options) *AppSourceV
 	return h
 }
 
-// GenerateRouter generates a VK router that uses an Source to serve data.
+// GenerateRouter generates a VK router that uses a Source to serve data.
 func (a *AppSourceVKRouter) GenerateRouter() (*vk.Router, error) {
 	if err := a.source.Start(a.options); err != nil {
 		return nil, errors.Wrap(err, "failed to source.Start")

--- a/system/source.go
+++ b/system/source.go
@@ -16,13 +16,13 @@ var (
 
 // Source describes how an entire system relays its state to a client
 type Source interface {
-	// Start indicates to the Source that it should prepare for app startup.
+	// Start indicates to the Source that it should prepare for system startup.
 	Start(opts Options) error
 
 	// State returns the state of the entire system, used for cache invalidation and sync purposes
 	State() (*State, error)
 
-	// Overview returns a the system overview, used for incremental sync of the system's applications
+	// Overview returns a the system overview, used for incremental sync of the system's tenants
 	Overview() (*Overview, error)
 
 	// TenantOverview returns the overview for the requested tenant
@@ -31,19 +31,19 @@ type Source interface {
 	// GetModule attempts to find the given module by its fqmn, and returns ErrRunnableNotFound if it cannot.
 	GetModule(FQMN string) (*tenant.Module, error)
 
-	// Workflows returns the requested workflows for the app.
+	// Workflows returns the requested workflows for the system.
 	Workflows(ident, namespace string, version int64) ([]tenant.Workflow, error)
 
-	// Connections returns the connections needed for the app.
+	// Connections returns the connections needed for the system.
 	Connections(ident, namespace string, version int64) ([]tenant.Connection, error)
 
-	// Authentication provides any auth headers or metadata for the app.
+	// Authentication provides any auth headers or metadata for the system.
 	Authentication(ident, namespace string, version int64) (*tenant.Authentication, error)
 
-	// Capabilities provides the application's configured capabilities.
+	// Capabilities provides the tenant's configured capabilities.
 	Capabilities(ident, namespace string, version int64) (*capabilities.CapabilityConfig, error)
 
-	// StaticFile is a source of static files for the application
+	// StaticFile is a source of static files for the tenant
 	StaticFile(identifier string, tenantVersion int64, path string) ([]byte, error)
 
 	// Queries returns the database queries that should be made available.

--- a/system/source.go
+++ b/system/source.go
@@ -1,4 +1,4 @@
-package appsource
+package system
 
 import (
 	"errors"
@@ -14,9 +14,9 @@ var (
 	ErrAuthenticationFailed = errors.New("failed to authenticate")
 )
 
-// AppSource describes how an entire system relays its state to a client
-type AppSource interface {
-	// Start indicates to the AppSource that it should prepare for app startup.
+// Source describes how an entire system relays its state to a client
+type Source interface {
+	// Start indicates to the Source that it should prepare for app startup.
 	Start(opts Options) error
 
 	// State returns the state of the entire system, used for cache invalidation and sync purposes

--- a/tenant/config.go
+++ b/tenant/config.go
@@ -140,7 +140,7 @@ func (c *Config) calculateFQMNs() {
 		}
 
 		// We deliberately ignore returned errors.
-		// The module will not be runnable, but it's not a problem for the
+		// The module will not be module, but it's not a problem for the
 		// system as a whole.
 		c.Modules[i].FQMN, _ = c.FQMNForFunc(mod.Namespace, mod.Name, mod.Ref)
 	}

--- a/tenant/config_test.go
+++ b/tenant/config_test.go
@@ -270,7 +270,7 @@ func TestConfigFQMNs(t *testing.T) {
 
 	mod5, _ := conf.FindModule("foo::bar")
 	if mod5 != nil {
-		t.Error("should not have found a Runnable for foo::bar")
+		t.Error("should not have found a Module for foo::bar")
 	}
 }
 

--- a/tenant/module.go
+++ b/tenant/module.go
@@ -6,10 +6,10 @@ type Module struct {
 	Namespace  string           `yaml:"namespace" json:"namespace"`
 	Lang       string           `yaml:"lang" json:"lang"`
 	Ref        string           `yaml:"ref" json:"ref"`
-	DraftRef   string           `yaml:"draftVersion,omitempty" json:"draftVersion,omitempty"`
+	DraftRef   string           `yaml:"draftRef,omitempty" json:"draftRef,omitempty"`
 	APIVersion string           `yaml:"apiVersion,omitempty" json:"apiVersion,omitempty"`
 	FQMN       string           `yaml:"fqmn,omitempty" json:"fqmn,omitempty"`
-	FQMNURI    string           `yaml:"fqmnUri" json:"fqmnURI,omitempty"`
+	URI        string           `yaml:"uri" json:"uri,omitempty"`
 	Revisions  []ModuleRevision `yaml:"revisions" json:"revisions"`
 	WasmRef    *WasmModuleRef   `yaml:"-" json:"wasmRef,omitempty"`
 	TokenHash  []byte           `yaml:"-" json:"-"`

--- a/tenant/tenant_validator.go
+++ b/tenant/tenant_validator.go
@@ -191,15 +191,15 @@ func (c *Config) validateSteps(exType executableType, name string, steps []execu
 		}
 
 		// this function is key as it compartmentalizes 'step validation', and importantly it
-		// ensures that a Runnable is available to handle it and binds it by setting the FQMN field.
+		// ensures that a Module is available to handle it and binds it by setting the FQMN field.
 		validateFn := func(mod *executable.ExecutableMod) {
-			runnable, err := c.FindModule(mod.FQMN)
+			module, err := c.FindModule(mod.FQMN)
 			if err != nil {
 				problems.add(fmt.Errorf("%s for %s lists mod at step %d that does not have a properly formed FQMN: %s", exType, name, j, mod.FQMN))
-			} else if runnable == nil {
+			} else if module == nil {
 				problems.add(fmt.Errorf("%s for %s lists mod at step %d that does not exist: %s (did you forget a namespace?)", exType, name, j, mod.FQMN))
 			} else {
-				mod.FQMN = runnable.FQMN
+				mod.FQMN = module.FQMN
 			}
 
 			for _, key := range mod.With {


### PR DESCRIPTION
This renames `appsource.AppSource` to `system.Source`

It also fixes some JSON/YAML tags on the `tenant.Module` struct.